### PR TITLE
Teach `TribeApplicationConfig` about custom app context paths.

### DIFF
--- a/server/src/main/kotlin/com/trib3/server/config/TribeApplicationConfig.kt
+++ b/server/src/main/kotlin/com/trib3/server/config/TribeApplicationConfig.kt
@@ -16,6 +16,7 @@ class TribeApplicationConfig
         val appName: String
         val corsDomains: List<String>
         val appPort: Int
+        val appContextPath: String
         val adminAuthToken: String?
         val httpsHeaders: List<String>
 
@@ -25,6 +26,7 @@ class TribeApplicationConfig
             appName = config.extract("application.name")
             corsDomains = config.extract("application.domains")
             appPort = config.extract<Int>("server.connector.port")
+            appContextPath = config.extract("server.applicationContextPath")
             adminAuthToken = config.extract("application.adminAuthToken")
             httpsHeaders = config.extract("application.httpsHeaders")
         }

--- a/server/src/main/kotlin/com/trib3/server/config/dropwizard/FilteredLogbackAccessRequestLogFactory.kt
+++ b/server/src/main/kotlin/com/trib3/server/config/dropwizard/FilteredLogbackAccessRequestLogFactory.kt
@@ -6,7 +6,11 @@ import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.pattern.PatternLayoutBase
 import ch.qos.logback.core.spi.FilterReply
+import com.fasterxml.jackson.annotation.JacksonInject
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeName
+import com.fasterxml.jackson.annotation.OptBoolean
+import com.trib3.server.config.TribeApplicationConfig
 import io.dropwizard.logging.common.async.AsyncAppenderFactory
 import io.dropwizard.logging.common.filter.LevelFilterFactory
 import io.dropwizard.logging.common.filter.NullLevelFilterFactory
@@ -51,7 +55,10 @@ class RequestIdLogbackAccessRequestLayoutFactory : LayoutFactory<IAccessEvent> {
  * layout pattern to include timestamp and requestId prefix.
  */
 @JsonTypeName("filtered-logback-access")
-class FilteredLogbackAccessRequestLogFactory : LogbackAccessRequestLogFactory() {
+class FilteredLogbackAccessRequestLogFactory(
+    @param:JacksonInject(useInput = OptBoolean.FALSE) @JsonIgnore
+    private val appConfig: TribeApplicationConfig,
+) : LogbackAccessRequestLogFactory() {
     override fun build(name: String): RequestLog {
         // almost the same as super.build(), differences are commented
         val logger =
@@ -73,11 +80,12 @@ class FilteredLogbackAccessRequestLogFactory : LogbackAccessRequestLogFactory() 
         }
 
         // add successful ping filter
+        val pingPath = "${appConfig.appContextPath}/ping"
         requestLog.addFilter(
             object : Filter<IAccessEvent>() {
                 override fun decide(event: IAccessEvent): FilterReply {
                     if (
-                        event.requestURI == "/app/ping" &&
+                        event.requestURI == pingPath &&
                         event.statusCode == HttpServletResponse.SC_OK &&
                         event.elapsedTime < FAST_RESPONSE_TIME
                     ) {

--- a/server/src/main/kotlin/com/trib3/server/resources/AuthCookieResource.kt
+++ b/server/src/main/kotlin/com/trib3/server/resources/AuthCookieResource.kt
@@ -55,7 +55,7 @@ class AuthCookieResource
                         NewCookie
                             .Builder(getCookieName())
                             .value(authToken)
-                            .path("/app")
+                            .path(appConfig.appContextPath)
                             .secure(containerRequestContext.securityContext.isSecure)
                             .httpOnly(true)
                             .build(),

--- a/server/src/main/kotlin/com/trib3/server/swagger/SwaggerInitializer.kt
+++ b/server/src/main/kotlin/com/trib3/server/swagger/SwaggerInitializer.kt
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.servers.Server
 import jakarta.inject.Inject
 import jakarta.ws.rs.core.Application
+import jakarta.ws.rs.core.UriBuilder
 
 // JaxrsOpenApiContextBuilder<T> needs to be subclassed in order to instantiate with a <T>
 private class SwaggerContextBuilder : JaxrsOpenApiContextBuilder<SwaggerContextBuilder>()
@@ -25,31 +26,36 @@ interface JaxrsAppProcessor {
 class SwaggerInitializer
     @Inject
     constructor(
+        // this is tricky, but we want to document the jersey exposed APIs
+        // from within the admin servlet, and the swagger libraries don't
+        // make things easy.  Fake out the servlet context -> swagger context
+        // with what ServletConfigContextUtils.getContextIdFromServletConfig
+        // will generate for the actual servlet, then add the swagger servlet
+        val contextId: String =
+            OpenApiContext.OPENAPI_CONTEXT_ID_PREFIX + "servlet." +
+                OpenApiServlet::class.simpleName,
         val appConfig: TribeApplicationConfig,
         val objectMapper: ObjectMapper,
     ) : JaxrsAppProcessor {
         override fun process(application: Application) {
             ModelConverters.getInstance().addConverter(ModelResolver(objectMapper))
-            // this is tricky, but we want to document the jersey exposed APIs
-            // from within the admin servlet, and the swagger libraries don't
-            // make things easy.  Fake out the servlet context -> swagger context
-            // with what ServletConfigContextUtils.getContextIdFromServletConfig
-            // will generate for the actual servlet, then add the swagger servlet
-            val ctxId = OpenApiContext.OPENAPI_CONTEXT_ID_PREFIX + "servlet." + OpenApiServlet::class.simpleName
+            val hostAndPath = UriBuilder.newInstance().host(appConfig.corsDomains[0]).path(appConfig.appContextPath)
+            val baseUrls =
+                listOf(
+                    hostAndPath.clone().scheme("https"),
+                    hostAndPath.clone().scheme("http"),
+                    hostAndPath.clone().scheme("http").port(appConfig.appPort),
+                )
             SwaggerContextBuilder()
                 .openApiConfiguration(
                     SwaggerConfiguration()
                         .openAPI(
                             OpenAPI().servers(
-                                listOf(
-                                    Server().url("https://${appConfig.corsDomains[0]}/app"),
-                                    Server().url("http://${appConfig.corsDomains[0]}/app"),
-                                    Server().url("http://${appConfig.corsDomains[0]}:${appConfig.appPort}/app"),
-                                ),
+                                baseUrls.map { Server().url(it.build().toString()) },
                             ),
                         ).scannerClass(JaxrsApplicationScanner::class.qualifiedName),
                 ).application(application)
-                .ctxId(ctxId)
+                .ctxId(contextId)
                 .buildContext(true)
         }
     }

--- a/server/src/test/kotlin/com/trib3/server/config/TribeApplicationConfigTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/config/TribeApplicationConfigTest.kt
@@ -12,5 +12,12 @@ class TribeApplicationConfigTest {
         assertThat(config.env).isEqualTo("dev")
         assertThat(config.appName).isEqualTo("Test")
         assertThat(config.adminAuthToken).isEqualTo("SECRET")
+        assertThat(config.appContextPath).isEqualTo("/app")
+    }
+
+    @Test
+    fun testCustomAppContextPath() {
+        val config = TribeApplicationConfig(ConfigLoader("appContextPathTestCase"))
+        assertThat(config.appContextPath).isEqualTo("/custom")
     }
 }

--- a/server/src/test/kotlin/com/trib3/server/config/dropwizard/FilteredRequestLogTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/config/dropwizard/FilteredRequestLogTest.kt
@@ -9,6 +9,8 @@ import ch.qos.logback.access.common.spi.IAccessEvent
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.core.AppenderBase
 import com.google.common.collect.ImmutableList
+import com.trib3.config.ConfigLoader
+import com.trib3.server.config.TribeApplicationConfig
 import com.trib3.testing.LeakyMock
 import com.trib3.testing.server.TestServletContextRequest
 import io.dropwizard.logging.common.AppenderFactory
@@ -28,10 +30,13 @@ import org.testng.annotations.Test
 import java.util.TimeZone
 
 class FilteredRequestLogTest {
+    private val appConfig = TribeApplicationConfig(ConfigLoader())
+    private val customAppConfig = TribeApplicationConfig(ConfigLoader("appContextPathTestCase"))
+
     @Test
     fun testLogFilterExcludesPing() {
         val events = mutableListOf<IAccessEvent>()
-        val factory = FilteredLogbackAccessRequestLogFactory()
+        val factory = FilteredLogbackAccessRequestLogFactory(appConfig)
         factory.appenders =
             ImmutableList.of(
                 AppenderFactory<IAccessEvent> {
@@ -67,9 +72,48 @@ class FilteredRequestLogTest {
     }
 
     @Test
+    fun testLogFilterExcludesPingForCustomAppContextPath() {
+        val events = mutableListOf<IAccessEvent>()
+        val factory = FilteredLogbackAccessRequestLogFactory(customAppConfig)
+        factory.appenders =
+            ImmutableList.of(
+                AppenderFactory<IAccessEvent> {
+                    _,
+                    _,
+                    _,
+                    _,
+                    _,
+                    ->
+                    object : AppenderBase<IAccessEvent>() {
+                        override fun append(eventObject: IAccessEvent) {
+                            events.add(eventObject)
+                        }
+                    }.also { it.start() }
+                },
+            )
+        val logger = factory.build("test")
+        val mockRequest = LeakyMock.niceMock<Request>()
+        val mockResponse = LeakyMock.niceMock<Response>()
+        val connectionMetaData = LeakyMock.niceMock<ConnectionMetaData>()
+        // `/custom/ping` should be filtered with custom context path.
+        EasyMock.expect(mockRequest.httpURI).andReturn(HttpURI.from("/custom/ping")).anyTimes()
+        EasyMock.expect(mockRequest.headersNanoTime).andReturn(System.nanoTime() + 200_000_000).anyTimes()
+        EasyMock.expect(mockResponse.status).andReturn(HttpServletResponse.SC_OK).anyTimes()
+        EasyMock.expect(connectionMetaData.httpConfiguration).andReturn(HttpConfiguration()).anyTimes()
+        EasyMock.expect(connectionMetaData.protocol).andReturn("HTTP/1.1").anyTimes()
+        EasyMock.replay(mockRequest, mockResponse, connectionMetaData)
+        val handler = ServletContextHandler()
+        val channel = ServletChannel(handler, connectionMetaData)
+        val testRequest = TestServletContextRequest(handler, channel, mockRequest, mockResponse)
+
+        logger.log(testRequest, mockResponse)
+        assertThat(events).isEmpty()
+    }
+
+    @Test
     fun testLogFilterIncludesSlowPing() {
         val events = mutableListOf<IAccessEvent>()
-        val factory = FilteredLogbackAccessRequestLogFactory()
+        val factory = FilteredLogbackAccessRequestLogFactory(appConfig)
         factory.appenders =
             ImmutableList.of(
                 AppenderFactory<IAccessEvent> {
@@ -106,7 +150,7 @@ class FilteredRequestLogTest {
     @Test
     fun testLogFilterIncludesFailedPing() {
         val events = mutableListOf<IAccessEvent>()
-        val factory = FilteredLogbackAccessRequestLogFactory()
+        val factory = FilteredLogbackAccessRequestLogFactory(appConfig)
         factory.appenders =
             ImmutableList.of(
                 AppenderFactory<IAccessEvent> {
@@ -157,7 +201,7 @@ class FilteredRequestLogTest {
     @Test
     fun testLogFilterIncludesArbitrary() {
         val events = mutableListOf<IAccessEvent>()
-        val factory = FilteredLogbackAccessRequestLogFactory()
+        val factory = FilteredLogbackAccessRequestLogFactory(appConfig)
         factory.appenders =
             ImmutableList.of(
                 AppenderFactory<IAccessEvent> {

--- a/server/src/test/kotlin/com/trib3/server/config/dropwizard/HoconConfigurationTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/config/dropwizard/HoconConfigurationTest.kt
@@ -2,8 +2,10 @@ package com.trib3.server.config.dropwizard
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.trib3.config.ConfigLoader
-import com.trib3.json.ObjectMapperProvider
+import com.trib3.server.config.BootstrapConfig
+import com.trib3.server.modules.DefaultApplicationModule
 import io.dropwizard.configuration.FileConfigurationSourceProvider
 import io.dropwizard.core.Configuration
 import io.dropwizard.core.server.SimpleServerFactory
@@ -12,14 +14,18 @@ import io.dropwizard.jetty.HttpConnectorFactory
 import org.testng.annotations.Test
 
 class HoconConfigurationTest {
+    private val configLoader = ConfigLoader()
+    private val injector = BootstrapConfig(configLoader).getInjector(listOf(DefaultApplicationModule()))
+
     @Test
     fun testHoconFactory() {
-        val factoryFactory = HoconConfigurationFactoryFactory<Configuration>(ConfigLoader())
+        val factoryFactory = HoconConfigurationFactoryFactory<Configuration>(configLoader)
+        val mapper = injector.getInstance(ObjectMapper::class.java)
         val factory =
             factoryFactory.create(
                 Configuration::class.java,
                 Bootstrap<Configuration>(null).validatorFactory.validator,
-                ObjectMapperProvider().get(),
+                mapper,
                 "dw",
             )
         val config = factory.build(FileConfigurationSourceProvider(), "ignored")

--- a/server/src/test/kotlin/com/trib3/server/resources/AuthCookieResourceTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/resources/AuthCookieResourceTest.kt
@@ -82,6 +82,22 @@ class AuthCookieResourceTest : ResourceTestBase<AuthCookieResource>() {
     }
 
     @Test
+    fun testCustomContextPathCookiePath() {
+        val customAppConfig = TribeApplicationConfig(ConfigLoader("appContextPathTestCase"))
+        val rawResource = AuthCookieResource(customAppConfig)
+        val mockRequest = LeakyMock.mock<ContainerRequestContext>()
+        val mockSecContext = LeakyMock.mock<SecurityContext>()
+        EasyMock.expect(mockRequest.getHeaderString("Authorization")).andReturn("Basic dXNlcjoxMjM0NQ==")
+        EasyMock.expect(mockRequest.securityContext).andReturn(mockSecContext)
+        EasyMock.expect(mockSecContext.isSecure).andReturn(false)
+        EasyMock.replay(mockRequest, mockSecContext)
+        val response = rawResource.setAuthCookie(mockRequest)
+        assertThat(response.status).isEqualTo(HttpStatus.NO_CONTENT_204)
+        val cookie = response.cookies["TEST_AUTHORIZATION"]
+        assertThat(cookie?.path).isEqualTo("/custom")
+    }
+
+    @Test
     fun testNullAuthHeaderCase() {
         // test against the resource method directly
         val rawResource = AuthCookieResource(appConfig)

--- a/server/src/test/kotlin/com/trib3/server/swagger/SwaggerInitializerTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/swagger/SwaggerInitializerTest.kt
@@ -2,11 +2,13 @@ package com.trib3.server.swagger
 
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import com.trib3.config.ConfigLoader
 import com.trib3.json.ObjectMapperProvider
 import com.trib3.server.config.TribeApplicationConfig
 import io.swagger.v3.core.converter.ModelConverters
+import io.swagger.v3.oas.integration.OpenApiContextLocator
 import jakarta.ws.rs.core.Application
 import org.testng.annotations.Test
 
@@ -25,6 +27,7 @@ class SwaggerInitializerTest {
     fun testInlineClassPropertyNames() {
         val initializer =
             SwaggerInitializer(
+                "testInlineClassPropertyNames",
                 TribeApplicationConfig(ConfigLoader()),
                 ObjectMapperProvider().get(),
             )
@@ -33,5 +36,24 @@ class SwaggerInitializerTest {
         val schema = schemas["ModelWithInlineClass"]
         assertThat(schema).isNotNull()
         assertThat(schema!!.properties.keys).containsExactlyInAnyOrder("id", "name")
+    }
+
+    @Test
+    fun testServerUrlsForCustomAppContextPath() {
+        val initializer =
+            SwaggerInitializer(
+                "serverUrlsForCustomAppContextPath",
+                TribeApplicationConfig(ConfigLoader("appContextPathTestCase")),
+                ObjectMapperProvider().get(),
+            )
+        initializer.process(object : Application() {})
+        val context = OpenApiContextLocator.getInstance().getOpenApiContext("serverUrlsForCustomAppContextPath")
+        assertThat(context.read().servers.map { it.url }).isEqualTo(
+            listOf(
+                "https://localhost/custom",
+                "http://localhost/custom",
+                "http://localhost:9080/custom",
+            ),
+        )
     }
 }

--- a/server/src/test/resources/application.conf
+++ b/server/src/test/resources/application.conf
@@ -58,6 +58,11 @@ jvmMetricsTestCase: {
 highResolutionTestCase: {
   highResolution: true
 }
+appContextPathTestCase {
+  server {
+    applicationContextPath: /custom
+  }
+}
 type: cloudwatch
 # exclude c2 from all test cases
 excludes: [c2]


### PR DESCRIPTION
There are a few stragglers where Leaky Cauldron assumes that the app is mounted at `/app`. This commit wires them up to use `server.applicationContextPath` instead.

(I haven't tried it out with our grouper yet, though!)